### PR TITLE
2d version should be foremost in implementing a 2d concept (added `two_d` to involute_gear.scad `gear()`)

### DIFF
--- a/involute_gears.scad
+++ b/involute_gears.scad
@@ -308,7 +308,7 @@ module gear (
 	backlash=0,
 	twist=0,
 	involute_facets=0,
-	flat=false)
+	flat=false, two_d=false)
 {
 	if (circular_pitch==false && diametral_pitch==false)
 		echo("MCAD ERROR: gear module needs either a diametral_pitch or circular_pitch");
@@ -354,7 +354,18 @@ module gear (
 			0.70*circle_orbit_curcumference/circles,
 			(rim_radius-hub_diameter/2)*0.9);
 
-	difference()
+	//NOTE: doing this with a boolean isnt great, but passing all the variables is a PITA
+	if( two_d )
+	{   gear_shape (
+		number_of_teeth,
+		pitch_radius = pitch_radius,
+		root_radius = root_radius,
+		base_radius = base_radius,
+		outer_radius = outer_radius,
+		half_thick_angle = half_thick_angle,
+		involute_facets=involute_facets);
+	}
+	else difference()
 	{
 		union ()
 		{


### PR DESCRIPTION
Currently if the user wants to `linear_extrude` the involute gear he has to figure out the arguments of `gear_shape`, there is no good reason for this.

The use of `if` for this is a bit bad imo, problem is that passing the arguments is a pita.
